### PR TITLE
리프레시 토큰 재발급 오류 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 개발 환경 설정
 
-[AWS API SERVER](http://ec2-13-209-127-186.ap-northeast-2.compute.amazonaws.com)
+[AWS API SERVER](http://ec2-13-209-127-186.ap-northeast-2.compute.amazonaws.com:8080)
 ---
 
 * 루트 디렉토리(WEB3_4_Log4U_BE)에서 다음 명령 실행

--- a/src/main/java/com/example/log4u/common/oauth2/entity/RefreshToken.java
+++ b/src/main/java/com/example/log4u/common/oauth2/entity/RefreshToken.java
@@ -22,7 +22,7 @@ public class RefreshToken {
 	@Setter
 	private String name;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	@Setter
 	private String refresh;
 

--- a/src/main/java/com/example/log4u/common/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/log4u/common/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -76,7 +76,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 		String refresh = jwtUtil.createJwt(REFRESH_TOKEN_KEY, userId, name, role, refreshTokenValidityInSeconds);
 
 		// 리프레시 토큰 DB 저장
-		refreshTokenService.saveRefreshToken(null, name, refresh);
+		refreshTokenService.saveRefreshToken(name, refresh);
 
 		response.addCookie(createCookie(ACCESS_TOKEN_KEY, access));
 		response.addCookie(createCookie(REFRESH_TOKEN_KEY, refresh));

--- a/src/main/java/com/example/log4u/common/oauth2/service/RefreshTokenService.java
+++ b/src/main/java/com/example/log4u/common/oauth2/service/RefreshTokenService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import com.example.log4u.common.oauth2.entity.RefreshToken;
 import com.example.log4u.common.oauth2.repository.RefreshTokenRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -19,15 +20,20 @@ public class RefreshTokenService {
 	@Value("${jwt.refresh-token-expire-time-seconds}")
 	private long refreshTokenValidityInSeconds;
 
-	public void saveRefreshToken(Long userId, String name, String refresh) {
+	public void saveRefreshToken(String name, String refresh) {
 		Date date = new Date(System.currentTimeMillis() + refreshTokenValidityInSeconds);
 
 		RefreshToken refreshToken = new RefreshToken(
-			userId,
+			null,
 			name,
 			refresh,
 			date.toString()
 		);
 		refreshTokenRepository.save(refreshToken);
+	}
+
+	@Transactional
+	public void deleteRefreshToken(String refresh) {
+		refreshTokenRepository.deleteByRefresh(refresh);
 	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,6 +9,12 @@ spring:
     hibernate:
       ddl-auto: create
 
+
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
   datasource:
     url: jdbc:mysql://localhost:3307/log4u
     username: dev


### PR DESCRIPTION
## 📌 PR 제목
리프레시 토큰을 활용해 토큰 재발급 시 발생하는 오류 수정

## ✨ 변경 사항
<!-- 이번 PR에서 변경된 내용을 요약하여 설명 -->
리프레시 토큰 엔티티 생성할 때  id 값을 잘못 넣어서 오류가 발생해 id값 넣지 않도록 수정했음

## 🔍 변경 이유
<!-- 이번 PR이 필요한 이유 또는 해결하는 문제 -->
리프레시 토큰 재발급 시 발생하는 오류 수정
운영 서버에 반영되어야 해서 바로 머지합니다.

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항 -->
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 관련 테스트 코드 작성 및 통과 여부 확인

