### PR TITLE
다이어리 도메인 파사드 패턴 도입

### DIFF
--- a/src/main/java/com/example/log4u/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/example/log4u/domain/diary/controller/DiaryController.java
@@ -18,7 +18,7 @@ import com.example.log4u.common.oauth2.dto.CustomOAuth2User;
 import com.example.log4u.domain.diary.SortType;
 import com.example.log4u.domain.diary.dto.DiaryRequestDto;
 import com.example.log4u.domain.diary.dto.DiaryResponseDto;
-import com.example.log4u.domain.diary.service.DiaryService;
+import com.example.log4u.domain.diary.facade.DiaryFacade;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DiaryController {
 
-	private final DiaryService diaryService;
+	private final DiaryFacade diaryFacade;
 
 	@GetMapping("/users/{userId}")
 	public ResponseEntity<PageResponse<DiaryResponseDto>> getDiariesByUserId(
@@ -39,7 +39,7 @@ public class DiaryController {
 		@RequestParam(required = false) Long cursorId,
 		@RequestParam(defaultValue = "12") int size
 	) {
-		PageResponse<DiaryResponseDto> response = diaryService.getDiariesByCursor(customOAuth2User.getUserId(),
+		PageResponse<DiaryResponseDto> response = diaryFacade.getDiariesByCursor(customOAuth2User.getUserId(),
 			targetUserId, cursorId, size);
 
 		return ResponseEntity.ok(response);
@@ -50,7 +50,7 @@ public class DiaryController {
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
 		@Valid @RequestBody DiaryRequestDto request
 	) {
-		diaryService.saveDiary(customOAuth2User.getUserId(), request);
+		diaryFacade.createDiary(customOAuth2User.getUserId(), request);
 		return ResponseEntity.status(HttpStatus.CREATED).build();
 	}
 
@@ -63,7 +63,7 @@ public class DiaryController {
 		@RequestParam(defaultValue = "6") int size
 	) {
 		return ResponseEntity.ok(
-			diaryService.searchDiariesByCursor(keyword, sort, cursorId, size)
+			diaryFacade.searchDiariesByCursor(keyword, sort, cursorId, size)
 		);
 	}
 
@@ -72,7 +72,7 @@ public class DiaryController {
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
 		@PathVariable Long diaryId
 	) {
-		DiaryResponseDto diary = diaryService.getDiary(customOAuth2User.getUserId(), diaryId);
+		DiaryResponseDto diary = diaryFacade.getDiary(customOAuth2User.getUserId(), diaryId);
 		return ResponseEntity.ok(diary);
 	}
 
@@ -82,16 +82,16 @@ public class DiaryController {
 		@PathVariable Long diaryId,
 		@Valid @RequestBody DiaryRequestDto request
 	) {
-		diaryService.updateDiary(customOAuth2User.getUserId(), diaryId, request);
+		diaryFacade.updateDiary(customOAuth2User.getUserId(), diaryId, request);
 		return ResponseEntity.ok().build();
 	}
 
 	@DeleteMapping("/{diaryId}")
-	public ResponseEntity<?> deleteDiary(
+	public ResponseEntity<Void> deleteDiary(
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
 		@PathVariable Long diaryId
 	) {
-		diaryService.deleteDiary(customOAuth2User.getUserId(), diaryId);
+		diaryFacade.deleteDiary(customOAuth2User.getUserId(), diaryId);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 }

--- a/src/main/java/com/example/log4u/domain/diary/facade/DiaryFacade.java
+++ b/src/main/java/com/example/log4u/domain/diary/facade/DiaryFacade.java
@@ -1,0 +1,127 @@
+package com.example.log4u.domain.diary.facade;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+import com.example.log4u.common.dto.PageResponse;
+import com.example.log4u.domain.diary.SortType;
+import com.example.log4u.domain.diary.dto.DiaryRequestDto;
+import com.example.log4u.domain.diary.dto.DiaryResponseDto;
+import com.example.log4u.domain.diary.entity.Diary;
+import com.example.log4u.domain.diary.service.DiaryService;
+import com.example.log4u.domain.like.service.LikeService;
+import com.example.log4u.domain.map.service.MapService;
+import com.example.log4u.domain.media.entity.Media;
+import com.example.log4u.domain.media.service.MediaService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DiaryFacade {
+
+	private final DiaryService diaryService;
+	private final MediaService mediaService;
+	private final MapService mapService;
+	private final LikeService likeService;
+
+	/**
+	 * 다이어리 생성 use case
+	 * <ul><li>호출 과정</li></ul>
+	 * 1. mediaService: 섬네일 이미지 url 생성<br>
+	 * 2. diaryService: 다이어리 생성<br>
+	 * 2. mediaService: 해당 다이어리의 이미지 저장<br>
+	 * 3. mapService: 해당 구역 카운트 증가
+	 * */
+	public void createDiary(Long userId, DiaryRequestDto request) {
+		String thumbnailUrl = mediaService.extractThumbnailUrl(request.mediaList());
+		Diary diary = diaryService.saveDiary(userId, request, thumbnailUrl);
+		mediaService.saveMedia(diary.getDiaryId(), request.mediaList());
+		mapService.increaseRegionDiaryCount(request.location().latitude(), request.location().longitude());
+	}
+
+	/**
+	 * 다이어리 삭제 use case
+	 * <ul><li>호출 과정</li></ul>
+	 * 1. diaryService: 다이어리 검증
+	 * 2. mediaService: 해당 다이어리 이미지 삭제<br>
+	 * 3. diaryService: 다이어리 삭제<br>
+	 * */
+	public void deleteDiary(Long userId, Long diaryId) {
+		Diary diary = diaryService.getDiaryAfterValidateOwnership(userId, diaryId);
+		mediaService.deleteMediaByDiaryId(diaryId);
+		diaryService.deleteDiary(diary);
+	}
+
+	/**
+	 * 다이어리 수정 use case
+	 * <ul><li>호출 과정</li></ul>
+	 * 1. diaryService: 다이어리 검증<br>
+	 * 2. mediaService: 해당 다이어리 이미지 삭제<br>
+	 * 3. diaryService: 다이어리 수정
+	 * */
+	public void updateDiary(Long userId, Long diaryId, DiaryRequestDto request) {
+		Diary diary = diaryService.getDiaryAfterValidateOwnership(userId, diaryId);
+		if (request.mediaList() != null) {
+			mediaService.updateMediaByDiaryId(diary.getDiaryId(), request.mediaList());
+		}
+		String newThumbnailUrl = mediaService.extractThumbnailUrl(request.mediaList());
+		diaryService.updateDiary(diary, request, newThumbnailUrl);
+	}
+
+	/**
+	 * 다이어리 단건 조회 use case
+	 * <ul><li>호출 과정</li></ul>
+	 * 1. diaryService: 공개 범위 검증 후 다이어리 조회<br>
+	 * 2. likeService: 좋아요 기록 조회<br>
+	 * 3. mediaService: 해당 다이어리의 이미지 조회<br>
+	 * 4. 모든 정보 조합 후 dto 변환 해 반환
+	 * */
+	public DiaryResponseDto getDiary(Long userId, Long diaryId) {
+		Diary diary = diaryService.getDiaryAfterValidateAccess(userId, diaryId);
+		boolean isLiked = likeService.isLiked(userId, diaryId);
+		List<Media> media = mediaService.getMediaByDiaryId(diary.getDiaryId());
+		return DiaryResponseDto.of(diary, media, isLiked);
+	}
+
+	/**
+	 * 다이어리 목록 조회 By UserId use case
+	 * <ul><li>호출 과정</li></ul>
+	 * 1. diaryService : DiaryResponseDto Slice 객체 조회<br>
+	 * 2. nextCursor 정보 생성<br>
+	 * 3. PageResponse 조합 후 반환
+	 * */
+	public PageResponse<DiaryResponseDto> getDiariesByCursor(
+		Long userId,
+		Long targetUserId,
+		Long cursorId,
+		int size
+	) {
+		Slice<DiaryResponseDto> dtoSlice = diaryService.getDiaryResponseDtoSlice(userId, targetUserId, cursorId, size);
+		// 다음 커서 ID 계산
+		Long nextCursor = !dtoSlice.isEmpty() ? dtoSlice.getContent().getLast().diaryId() : null;
+		return PageResponse.of(dtoSlice, nextCursor);
+	}
+
+	/**
+	 * 다이어리 검색 목록 조회 By Cursor use case
+	 * <ul><li>호출 과정</li></ul>
+	 * 1. diaryService : DiaryResponseDto Slice 객체 조회<br>
+	 * 2. nextCursor 정보 생성<br>
+	 * 3. PageResponse 조합 후 반환<br>
+	 * */
+	public PageResponse<DiaryResponseDto> searchDiariesByCursor(
+		String keyword,
+		SortType sort,
+		Long cursorId,
+		int size
+	) {
+		Slice<DiaryResponseDto> dtoSlice = diaryService.searchDiariesByCursor(keyword, sort, cursorId, size);
+		// 다음 커서 ID 계산
+		Long nextCursor = !dtoSlice.isEmpty() ? dtoSlice.getContent().getLast().diaryId() : null;
+		return PageResponse.of(dtoSlice, nextCursor);
+	}
+
+}

--- a/src/main/java/com/example/log4u/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/example/log4u/domain/diary/service/DiaryService.java
@@ -22,7 +22,6 @@ import com.example.log4u.domain.diary.exception.OwnerAccessDeniedException;
 import com.example.log4u.domain.diary.repository.DiaryRepository;
 import com.example.log4u.domain.follow.repository.FollowRepository;
 import com.example.log4u.domain.like.repository.LikeRepository;
-import com.example.log4u.domain.map.service.MapService;
 import com.example.log4u.domain.media.entity.Media;
 import com.example.log4u.domain.media.service.MediaService;
 
@@ -37,23 +36,17 @@ public class DiaryService {
 	private final DiaryRepository diaryRepository;
 	private final FollowRepository followRepository;
 	private final MediaService mediaService;
-	private final MapService mapService;
 	private final LikeRepository likeRepository;
 
 	// 다이어리 생성
 	@Transactional
-	public void saveDiary(Long userId, DiaryRequestDto request) {
-		String thumbnailUrl = mediaService.extractThumbnailUrl(request.mediaList());
-		Diary diary = diaryRepository.save(
-			DiaryRequestDto.toEntity(userId, request, thumbnailUrl)
-		);
-		mediaService.saveMedia(diary.getDiaryId(), request.mediaList());
-		mapService.increaseRegionDiaryCount(request.location().latitude(), request.location().longitude());
+	public Diary saveDiary(Long userId, DiaryRequestDto request, String thumbnailUrl) {
+		return diaryRepository.save(DiaryRequestDto.toEntity(userId, request, thumbnailUrl));
 	}
 
 	// 다이어리 검색
 	@Transactional(readOnly = true)
-	public PageResponse<DiaryResponseDto> searchDiariesByCursor(
+	public Slice<DiaryResponseDto> searchDiariesByCursor(
 		String keyword,
 		SortType sort,
 		Long cursorId,
@@ -66,17 +59,12 @@ public class DiaryService {
 			cursorId != null ? cursorId : Long.MAX_VALUE,
 			PageRequest.of(0, size)
 		);
-
-		Slice<DiaryResponseDto> dtoSlice = mapToDtoSlice(diaries);
-
-		// 다음 커서 ID 계산
-		Long nextCursor = !dtoSlice.isEmpty() ? dtoSlice.getContent().getLast().diaryId() : null;
-
-		return PageResponse.of(dtoSlice, nextCursor);
+		return mapToDtoSlice(diaries);
 	}
 
 	// 다이어리 상세 조회
 	@Transactional(readOnly = true)
+	@Deprecated(since = "파사드 패턴 도입으로 인해 불필요해짐", forRemoval = false)
 	public DiaryResponseDto getDiary(Long userId, Long diaryId) {
 		Diary diary = findDiaryOrThrow(diaryId);
 
@@ -89,43 +77,27 @@ public class DiaryService {
 
 	// 다이어리 목록 (프로필 페이지)
 	@Transactional(readOnly = true)
-	public PageResponse<DiaryResponseDto> getDiariesByCursor(Long userId, Long targetUserId, Long cursorId, int size) {
+	public Slice<DiaryResponseDto> getDiaryResponseDtoSlice(Long userId, Long targetUserId, Long cursorId, int size) {
 		List<VisibilityType> visibilities = determineAccessibleVisibilities(userId, targetUserId);
-
 		Slice<Diary> diaries = diaryRepository.findByUserIdAndVisibilityInAndCursorId(
 			targetUserId,
 			visibilities,
 			cursorId != null ? cursorId : Long.MAX_VALUE,
 			PageRequest.of(0, size)
 		);
-
-		Slice<DiaryResponseDto> dtoSlice = mapToDtoSlice(diaries);
-
-		Long nextCursor = !dtoSlice.isEmpty() ? dtoSlice.getContent().getLast().diaryId() : null;
-
-		return PageResponse.of(dtoSlice, nextCursor);
+		return mapToDtoSlice(diaries);
 	}
 
 	// 다이어리 수정
 	@Transactional
-	public void updateDiary(Long userId, Long diaryId, DiaryRequestDto request) {
-		Diary diary = findDiaryOrThrow(diaryId);
-		validateOwner(diary, userId);
-
-		if (request.mediaList() != null) {
-			mediaService.updateMediaByDiaryId(diary.getDiaryId(), request.mediaList());
-		}
-
-		String newThumbnailUrl = mediaService.extractThumbnailUrl(request.mediaList());
+	public void updateDiary(Diary diary, DiaryRequestDto request, String newThumbnailUrl) {
 		diary.update(request, newThumbnailUrl);
+		diaryRepository.save(diary);
 	}
 
 	// 다이어리 삭제
 	@Transactional
-	public void deleteDiary(Long userId, Long diaryId) {
-		Diary diary = findDiaryOrThrow(diaryId);
-		validateOwner(diary, userId);
-		mediaService.deleteMediaByDiaryId(diaryId);
+	public void deleteDiary(Diary diary) {
 		diaryRepository.delete(diary);
 	}
 
@@ -173,7 +145,7 @@ public class DiaryService {
 		}
 	}
 
-	// 다이어리 목록 조회 시 권한 체크
+	// 다이어리 목록 조회 시 권한 체크(공개 정책)
 	private List<VisibilityType> determineAccessibleVisibilities(Long userId, Long targetUserId) {
 		if (userId.equals(targetUserId)) {
 			return List.of(VisibilityType.PUBLIC, VisibilityType.PRIVATE, VisibilityType.FOLLOWER);
@@ -184,6 +156,20 @@ public class DiaryService {
 		}
 
 		return List.of(VisibilityType.PUBLIC);
+	}
+
+	// 파사드 패턴에서 사용할 검증 로직(소유 검증)
+	public Diary getDiaryAfterValidateOwnership(Long diaryId, Long userId) {
+		Diary diary = findDiaryOrThrow(diaryId);
+		validateOwner(diary, userId);
+		return diary;
+	}
+
+	// 파사드 패턴에서 사용할 검증 로직(공개 범위 검증)
+	public Diary getDiaryAfterValidateAccess(Long diaryId, Long userId) {
+		Diary diary = findDiaryOrThrow(diaryId);
+		validateDiaryAccess(diary, userId);
+		return diary;
 	}
 
 	// 다이어리 상세 조회 시 권한 체크

--- a/src/main/java/com/example/log4u/domain/like/service/LikeService.java
+++ b/src/main/java/com/example/log4u/domain/like/service/LikeService.java
@@ -1,7 +1,5 @@
 package com.example.log4u.domain.like.service;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,5 +49,10 @@ public class LikeService {
 		if (likeRepository.existsByUserIdAndDiaryId(userId, diaryId)) {
 			throw new DuplicateLikeException();
 		}
+	}
+
+	// 파사드 패턴에서 사용할 함수
+	public boolean isLiked(Long userId, Long diaryId) {
+		return likeRepository.existsByUserIdAndDiaryId(userId, diaryId);
 	}
 }


### PR DESCRIPTION
## 📌 PR 제목
<!-- 간결하고 명확한 PR 제목 작성 -->
다이어리 도메인 파사드 패턴 도입

## ✨ 변경 사항
<!-- 이번 PR에서 변경된 내용을 요약하여 설명 -->
- DiaryFacade 클래스 추가
- DiaryFacade 테스트 추가 (예정)
- DiaryServiceTest 수정
- LikeService 수정


## 🔍 변경 이유
<!-- 이번 PR이 필요한 이유 또는 해결하는 문제 -->
기존의 코드 베이스 에서는 한 도메인의 서비스가 다른 도메인의 서비스를 호출하기 위해서 

1. 필요한 기능이 존재하는 다른 서비스를 주입받아  호출
2. 레포지토리에서 직접 데이터 조회 후 가공

위 두 가지 방법을 혼용해서 썼습니다.

이러한 방식의 문제점은 다음과 같습니다.

1. 서비스가 서비스 호출하는 경우 의존성 관계가 복잡해져 잠재적 순환 참조 오류
2. 자신의 도메인이 아닌 외부 레포지토리에서 직접 조회해서 가공 하는 것이 서비스 도메인 역할에 맞지 않음

따라서 파사드 클래스를 도입해 해결하고자 하였습니다.

파사드 클래스는 사용자 관점에서의 유즈 케이스에 관심사를 두어서,
파사드 클래스에 대한 테스트를 수행하는 것이 곧 유즈케이스에 대한 통합 테스트를 수행하는 것이 되도록 했습니다.


서비스 리팩토링 시 관심사는 다음과 같았습니다.

1. 한 서비스가 외부 서비스, 레포지토리 의존을 최소화해서 단일 기능에 집중.
2. 서비스에서 서비스 의존은 되도록 하지말고, 필요하면 레포지토리 의존할 것
3. 해당 도메인에 대한 검증 로직(각 도메인에 맞는 Exception 발생이 필요한 경우) 은 서비스 레이어에서 수행.

파사드 클래스는 이러한 방식으로 설계된 서비스 코드들의 흐름을 조합, 제어해서 
각 유즈케이스에 따른 원하는 결과를 도출하도록 작성했습니다.

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항 -->
- [ ] 코드가 정상적으로 동작하는지 확인
- [ ] 관련 테스트 코드 작성 및 통과 여부 확인
- [ ] 문서화(README 등) 필요 여부 확인 및 반영
- [ ] 리뷰어가 알아야 할 사항 추가 설명

## 📸 스크린샷 (선택)
<!-- UI 변경이 포함된 경우 관련 스크린샷 첨부 -->

## 📌 참고 사항
<!-- 기타 리뷰어가 참고해야 할 사항 -->
