### PR TITLE
데이터소스 환경에 LazyConnection 프록시 적용

### DIFF
--- a/src/main/java/com/example/log4u/common/config/MySqlConfig.java
+++ b/src/main/java/com/example/log4u/common/config/MySqlConfig.java
@@ -17,6 +17,9 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
 @Configuration
 @EnableJpaRepositories(
@@ -41,27 +44,35 @@ public class MySqlConfig {
 	@Bean
 	@Primary
 	@ConfigurationProperties(prefix = "spring.datasource")
-	public DataSource mysqlDataSource() {
+	public HikariDataSource mysqlHikariDataSource() {
 		HikariDataSource dataSource = DataSourceBuilder.create()
 			.type(HikariDataSource.class)
 			.build();
 
-		// Hikari 커넥션 풀 설정
-		dataSource.setMaximumPoolSize(10);         // 최대 커넥션 수
-		dataSource.setMinimumIdle(10);             // 최소 유휴 커넥션
-		dataSource.setIdleTimeout(30000);          // 유휴 커넥션 유지 시간 (30초)
-		dataSource.setConnectionTimeout(3000);     // 커넥션 대기 시간 (3초)
-		dataSource.setMaxLifetime(1800000);        // 커넥션 최대 수명 (30분)
+		dataSource.setMaximumPoolSize(10);
+		dataSource.setMinimumIdle(10);
+		dataSource.setIdleTimeout(30000);
+		dataSource.setConnectionTimeout(3000);
+		dataSource.setMaxLifetime(1800000);
 
 		return dataSource;
 	}
 
+	@Bean(name = "mysqlDataSource")
+	@Primary
+	public DataSource mysqlDataSource(
+		@Qualifier("mysqlHikariDataSource") HikariDataSource hikariDataSource
+	) {
+		return new LazyConnectionDataSourceProxy(hikariDataSource);
+	}
 
 	@Bean(name = "mysqlEntityManagerFactory")
 	@Primary
-	public LocalContainerEntityManagerFactoryBean mysqlEntityManagerFactory() {
+	public LocalContainerEntityManagerFactoryBean mysqlEntityManagerFactory(
+		@Qualifier("mysqlDataSource") DataSource dataSource
+	) {
 		LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
-		em.setDataSource(mysqlDataSource());
+		em.setDataSource(dataSource);
 		em.setPackagesToScan(
 			"com.example.log4u.common",
 			"com.example.log4u.domain.comment",
@@ -75,6 +86,7 @@ public class MySqlConfig {
 			"com.example.log4u.domain.subscription",
 			"com.example.log4u.domain.hashtag"
 		);
+
 		HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
 		vendorAdapter.setShowSql(true);
 		vendorAdapter.setGenerateDdl(true);
@@ -91,9 +103,11 @@ public class MySqlConfig {
 
 	@Bean(name = "mysqlTransactionManager")
 	@Primary
-	public PlatformTransactionManager mysqlTransactionManager() {
+	public PlatformTransactionManager mysqlTransactionManager(
+		@Qualifier("mysqlEntityManagerFactory") LocalContainerEntityManagerFactoryBean mysqlEmf
+	) {
 		JpaTransactionManager transactionManager = new JpaTransactionManager();
-		transactionManager.setEntityManagerFactory(mysqlEntityManagerFactory().getObject());
+		transactionManager.setEntityManagerFactory(mysqlEmf.getObject());
 		return transactionManager;
 	}
 }

--- a/src/main/java/com/example/log4u/common/config/PostgreSqlConfig.java
+++ b/src/main/java/com/example/log4u/common/config/PostgreSqlConfig.java
@@ -14,6 +14,9 @@ import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
 @Configuration
 @EnableJpaRepositories(
@@ -27,14 +30,25 @@ public class PostgreSqlConfig {
 
 	@Bean
 	@ConfigurationProperties(prefix = "spring.second-datasource")
-	public DataSource postgresqlDataSource() {
-		return DataSourceBuilder.create().build();
+	public HikariDataSource postgresqlHikariDataSource() {
+		return DataSourceBuilder.create()
+			.type(HikariDataSource.class)
+			.build();
+	}
+
+	@Bean(name = "postgresqlDataSource")
+	public DataSource postgresqlDataSource(
+		@Qualifier("postgresqlHikariDataSource") HikariDataSource hikariDataSource
+	) {
+		return new LazyConnectionDataSourceProxy(hikariDataSource);
 	}
 
 	@Bean(name = "postgresqlEntityManagerFactory")
-	public LocalContainerEntityManagerFactoryBean postgresqlEntityManagerFactory() {
+	public LocalContainerEntityManagerFactoryBean postgresqlEntityManagerFactory(
+		@Qualifier("postgresqlDataSource") DataSource dataSource
+	) {
 		LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
-		em.setDataSource(postgresqlDataSource());
+		em.setDataSource(dataSource);
 		em.setPackagesToScan("com.example.log4u.domain.map.entity");
 
 		HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
@@ -52,9 +66,11 @@ public class PostgreSqlConfig {
 	}
 
 	@Bean(name = "postgresqlTransactionManager")
-	public PlatformTransactionManager postgresqlTransactionManager() {
+	public PlatformTransactionManager postgresqlTransactionManager(
+		@Qualifier("postgresqlEntityManagerFactory") LocalContainerEntityManagerFactoryBean postgresqlEmf
+	) {
 		JpaTransactionManager transactionManager = new JpaTransactionManager();
-		transactionManager.setEntityManagerFactory(postgresqlEntityManagerFactory().getObject());
+		transactionManager.setEntityManagerFactory(postgresqlEmf.getObject());
 		return transactionManager;
 	}
 }


### PR DESCRIPTION


## ✨ 변경 사항
<!-- 이번 PR에서 변경된 내용을 요약하여 설명 -->
- MySQL & PostgreSQL 설정에 LazyConnectionDataSourceProxy 추가

## 🔍 변경 이유
<!-- 이번 PR이 필요한 이유 또는 해결하는 문제 -->

Thread 100개가 geohash 'wydm6' 문자열 내 다이어리 조회 부하 테스트를 걸어놓고 모니터링을 해보니 예상과는 다르게 DB connection을 모든 thread가 요청하고 있음

<img width="1280" height="539" alt="image" src="https://github.com/user-attachments/assets/205a2ac3-3faf-416a-9cc3-3c9ff0911f9f" />


Spring에서 기본적으로 Transaction에 진입하는 순간, 설정된 DataSource의 connection을 바로 가져온다. 따라서 실제로 DB connection을 사용하고 있지 않는데도 계속해서 점유하고 있는 문제가 발생

LazyConnectionDataSource 사용하여 실제로 Connection이 필요한 시점에서야 DB connection을 획득하도록 요청
 
<img width="2838" height="1196" alt="image" src="https://github.com/user-attachments/assets/6913852b-eae7-420c-84d3-5a7c6f2fdf5f" />


## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항 -->
- [ ] 코드가 정상적으로 동작하는지 확인
- [ ] 관련 테스트 코드 작성 및 통과 여부 확인
- [ ] 문서화(README 등) 필요 여부 확인 및 반영
- [ ] 리뷰어가 알아야 할 사항 추가 설명

## 📸 스크린샷 (선택)
<!-- UI 변경이 포함된 경우 관련 스크린샷 첨부 -->

## 📌 참고 사항
<!-- 기타 리뷰어가 참고해야 할 사항 -->
