### PR TITLE
Redis 캐시 압축 적용(GZIP)으로 geohash 캐싱 최적화

### DIFF
--- a/src/main/java/com/example/log4u/common/config/redis/GzipRedisSerializer.java
+++ b/src/main/java/com/example/log4u/common/config/redis/GzipRedisSerializer.java
@@ -1,0 +1,132 @@
+package com.example.log4u.common.config.redis;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.Deflater;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+import org.springframework.util.FileCopyUtils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GzipRedisSerializer<T> implements RedisSerializer<T> {
+
+    private static final byte[] GZIP_MAGIC_BYTES = new byte[]{
+            (byte) (GZIPInputStream.GZIP_MAGIC & 0xFF),
+            (byte) ((GZIPInputStream.GZIP_MAGIC >> 8) & 0xFF)
+    };
+
+    private final ObjectMapper objectMapper;
+    private final TypeReference<T> typeReference;
+    private final int minCompressionSize;
+    private final int bufferSize;
+
+    public GzipRedisSerializer(ObjectMapper objectMapper, TypeReference<T> typeReference) {
+        this(objectMapper, typeReference, 1024, 4096);
+    }
+
+    @Override
+    public byte[] serialize(T t) throws SerializationException {
+        if (t == null) {
+            return null;
+        }
+        try {
+            if (minCompressionSize == -1) {
+                return encodeGzip(t);
+            }
+            byte[] bytes = objectMapper.writeValueAsBytes(t);
+            if (bytes.length <= minCompressionSize) {
+                return bytes;
+            }
+            return encodeGzip(t);
+
+        } catch (Exception e) {
+            throw new SerializationException("Failed to serialize", e);
+        }
+    }
+
+    @Override
+    public T deserialize(byte[] bytes) throws SerializationException {
+        if (bytes == null) {
+            return null;
+        }
+        try {
+            if (isGzipCompressed(bytes)) {
+                byte[] decompressed = decodeGzip(bytes);
+                return objectMapper.readValue(decompressed, 0, decompressed.length, typeReference);
+            }
+            return objectMapper.readValue(bytes, 0, bytes.length, typeReference);
+
+        } catch (IOException e) {
+            throw new SerializationException("Failed to deserialize", e);
+        }
+    }
+
+    private byte[] encodeGzip(byte[] original) {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream(bufferSize);
+             GZIPOutputStream gos = new GZIPOutputStream(bos, bufferSize) {
+                 {
+                     def.setLevel(Deflater.BEST_SPEED);
+                 }
+             }
+        ) {
+            FileCopyUtils.copy(original, gos);
+            return bos.toByteArray();
+
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to encode GZIP", e);
+        }
+    }
+
+    private byte[] encodeGzip(T t) {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream(bufferSize);
+             GZIPOutputStream gos = new GZIPOutputStream(bos, bufferSize) {
+                 {
+                     def.setLevel(Deflater.BEST_SPEED);
+                 }
+             }
+        ) {
+            objectMapper.writeValue(gos, t);
+            return bos.toByteArray();
+
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to encode GZIP", e);
+        }
+    }
+
+    private byte[] decodeGzip(byte[] encoded) {
+        try (
+                ByteArrayInputStream bis = new ByteArrayInputStream(encoded);
+                GZIPInputStream gis = new GZIPInputStream(bis, bufferSize);
+                ExposedBufferByteArrayOutputStream out = new ExposedBufferByteArrayOutputStream(bufferSize);
+        ) {
+            FileCopyUtils.copy(gis, out);
+            return out.getRawByteArray();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to decode GZIP", e);
+        }
+    }
+
+    private boolean isGzipCompressed(byte[] bytes) {
+        return bytes.length > 2 && bytes[0] == GZIP_MAGIC_BYTES[0] && bytes[1] == GZIP_MAGIC_BYTES[1];
+    }
+
+    static class ExposedBufferByteArrayOutputStream extends ByteArrayOutputStream {
+
+        ExposedBufferByteArrayOutputStream(int size) {
+            super(size);
+        }
+
+        public byte[] getRawByteArray() {
+            return this.buf;
+        }
+    }
+}

--- a/src/main/java/com/example/log4u/common/config/redis/RedisConfig.java
+++ b/src/main/java/com/example/log4u/common/config/redis/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
@@ -23,12 +24,16 @@ public class RedisConfig {
 		RedisTemplate<String, String> template = new RedisTemplate<>();
 		template.setConnectionFactory(redisConnectionFactory);
 		template.setKeySerializer(new StringRedisSerializer());
-		template.setValueSerializer(new StringRedisSerializer());
+		template.setValueSerializer(new GzipRedisSerializer<>(
+			ObjectMapperFactory.objectMapper, new TypeReference<String>() {
+		}, 1024, 4096));
 		return template;
 	}
 
 	@Bean
 	public ObjectMapper objectMapper() {
-		return ObjectMapperFactory.objectMapper;
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		return objectMapper;
 	}
 }


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이번 PR에서 변경된 내용을 요약하여 설명 -->

- GzipRedisSerializer를 통해서 직렬화 & 역직렬화 수행

## 🔍 변경 이유
<!-- 이번 PR이 필요한 이유 또는 해결하는 문제 -->

- `wydm6`처럼 다이어리 밀집도가 높은 geohash 구역은 캐시 데이터 크기가 7MB 이상으로 매우 커 
Redis 메모리 사용량과 네트워크 전송 비용이 불필요하게 증가함
- Redis에 저장되는 데이터의 크기가 7.7 MB에서 0.7 MB로 감소함


## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항 -->
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 관련 테스트 코드 작성 및 통과 여부 확인
- [x] 문서화(README 등) 필요 여부 확인 및 반영
- [x] 리뷰어가 알아야 할 사항 추가 설명

## 📸 스크린샷 (선택)
<!-- UI 변경이 포함된 경우 관련 스크린샷 첨부 -->

## 📌 참고 사항
<!-- 기타 리뷰어가 참고해야 할 사항 -->
