### PR TITLE
지도 마커형 캐싱 기능 리팩토링

### DIFF
--- a/src/main/java/com/example/log4u/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/example/log4u/domain/diary/repository/DiaryRepository.java
@@ -19,6 +19,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, CustomDiary
 		FROM Diary d
 		JOIN DiaryGeoHash g ON d.diaryId = g.diaryId
 		WHERE g.geohash = :geohash
+		AND d.visibility = 'PUBLIC';
 		""",
 		nativeQuery = true)
 	List<Diary> findDiariesByGeohash(@Param("geohash") String geohash);
@@ -28,6 +29,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, CustomDiary
 		FROM Diary d
 		JOIN DiaryGeoHash g ON d.diaryId = g.diaryId
 		WHERE g.geohash = :geohash
+		AND d.visibility = 'PUBLIC';
 		""",
 		nativeQuery = true)
 	List<Diary> findDiariesByGeohashByIndexScan(@Param("geohash") String geohash);

--- a/src/main/java/com/example/log4u/domain/map/cache/DiaryUtils.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/DiaryUtils.java
@@ -1,0 +1,23 @@
+package com.example.log4u.domain.map.cache;
+
+import java.util.List;
+
+import com.example.log4u.domain.diary.entity.Diary;
+
+import java.util.Comparator;
+
+public class DiaryUtils {
+
+	private static final int MAX_DIARIES_LIMIT = 300;
+
+	public static List<Diary> topByLikes(List<Diary> diaries) {
+		if (diaries == null || diaries.isEmpty()) {
+			return List.of();
+		}
+
+		return diaries.stream()
+			.sorted(Comparator.comparingLong(Diary::getLikeCount).reversed())
+			.limit(MAX_DIARIES_LIMIT)
+			.toList();
+	}
+}

--- a/src/main/java/com/example/log4u/domain/map/cache/MarkersCacheService.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/MarkersCacheService.java
@@ -5,8 +5,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.example.log4u.common.executor.RetryExecutor;
+import com.example.log4u.domain.diary.entity.Diary;
 import com.example.log4u.domain.map.cache.manager.MarkersCacheManager;
-import com.example.log4u.domain.map.dto.response.GetDiaryMarkerResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +29,16 @@ public class MarkersCacheService {
 				markers = markersCacheManager.loadAndCache(geohash);
 			}
 			return markers;
+		});
+	}
+
+	public List<Diary> getTopLikedMarkers(String geohash) {
+		return retryExecutor.runWithRetry(() -> {
+			List<Diary> markers = markersCacheManager.load(geohash);
+			if (markers == null) {
+				markers = markersCacheManager.loadAndCache(geohash);
+			}
+			return DiaryUtils.topByLikes(markers);
 		});
 	}
 }

--- a/src/main/java/com/example/log4u/domain/map/cache/MarkersCacheService.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/MarkersCacheService.java
@@ -22,9 +22,9 @@ public class MarkersCacheService {
 		markersCacheManager.refresh(geohash);
 	}
 
-	public List<GetDiaryMarkerResponse> getMarkers(String geohash) {
+	public List<Diary> getMarkers(String geohash) {
 		return retryExecutor.runWithRetry(() -> {
-			List<GetDiaryMarkerResponse> markers = markersCacheManager.load(geohash);
+			List<Diary> markers = markersCacheManager.load(geohash);
 			if (markers == null) {
 				markers = markersCacheManager.loadAndCache(geohash);
 			}

--- a/src/main/java/com/example/log4u/domain/map/cache/MarkersLocalCacheService.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/MarkersLocalCacheService.java
@@ -25,15 +25,15 @@ public class MarkersLocalCacheService {
 		markersLocalCacheManager.evict(geohash);
 	}
 
-	public List<GetDiaryMarkerResponse> getMarkers(String geohash) {
+	public List<Diary> getTopLikedMarkers(String geohash) {
 		return retryExecutor.runWithRetry(() -> {
-			List<GetDiaryMarkerResponse> markers = loadWithFallback(geohash);
+			List<Diary> markers = loadWithFallback(geohash);
 			return markers;
 		});
 	}
 
-	private List<GetDiaryMarkerResponse> loadWithFallback(String geohash) {
-		List<GetDiaryMarkerResponse> markers = markersLocalCacheManager.load(geohash);
+	private List<Diary> loadWithFallback(String geohash) {
+		List<Diary> markers = markersLocalCacheManager.load(geohash);
 		if (markers != null) {
 			return markers;
 		}

--- a/src/main/java/com/example/log4u/domain/map/cache/MarkersLocalCacheService.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/MarkersLocalCacheService.java
@@ -5,9 +5,9 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.example.log4u.common.executor.RetryExecutor;
+import com.example.log4u.domain.diary.entity.Diary;
 import com.example.log4u.domain.map.cache.manager.MarkersCacheManager;
 import com.example.log4u.domain.map.cache.manager.MarkersLocalCacheManager;
-import com.example.log4u.domain.map.dto.response.GetDiaryMarkerResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,7 +28,7 @@ public class MarkersLocalCacheService {
 	public List<Diary> getTopLikedMarkers(String geohash) {
 		return retryExecutor.runWithRetry(() -> {
 			List<Diary> markers = loadWithFallback(geohash);
-			return markers;
+			return DiaryUtils.topByLikes(markers);
 		});
 	}
 

--- a/src/main/java/com/example/log4u/domain/map/cache/manager/MarkersCacheManager.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/manager/MarkersCacheManager.java
@@ -37,12 +37,12 @@ public class MarkersCacheManager {
 
 		distributedLockExecutor.runWithLock(lockKey, () -> {
 			cacheManager.evict(cacheKey);
-			List<GetDiaryMarkerResponse> markers = loadMarkersFromDb(geohash);
+			List<Diary> markers = loadMarkersFromDb(geohash);
 			cache(markers, geohash);
 		});
 	}
 
-	public List<GetDiaryMarkerResponse> load(String geohash) {
+	public List<Diary> load(String geohash) {
 		String key = MARKER_CACHE_KEY.formatted(geohash);
 		String value = cacheManager.get(key);
 		if (value == null) {
@@ -51,29 +51,26 @@ public class MarkersCacheManager {
 		return convertToMarkers(value);
 	}
 
-	private List<GetDiaryMarkerResponse> convertToMarkers(String value) {
+	private List<Diary> convertToMarkers(String value) {
 		return readValue(value, new TypeReference<>() {
 		});
 	}
 
-	public List<GetDiaryMarkerResponse> loadAndCache(String geohash) {
+	public List<Diary> loadAndCache(String geohash) {
 		String lockKey = MARKER_LOCK_KEY.formatted(geohash);
 
 		return distributedLockExecutor.runWithLock(lockKey, () -> {
-				List<GetDiaryMarkerResponse> markers = loadMarkersFromDb(geohash);
+				List<Diary> markers = loadMarkersFromDb(geohash);
 				cache(markers, geohash);
 				return markers;
 			});
 	}
 
-	private List<GetDiaryMarkerResponse> loadMarkersFromDb(String geohash) {
-		List<Diary> diaries = diaryRepository.findDiariesByGeohash(geohash);
-		return diaries.stream()
-			.map(GetDiaryMarkerResponse::of)
-			.toList();
+	private List<Diary> loadMarkersFromDb(String geohash) {
+		return diaryRepository.findDiariesByGeohash(geohash);
 	}
 
-	private void cache(List<GetDiaryMarkerResponse> markers, String geohash) {
+	private void cache(List<Diary> markers, String geohash) {
 		String key = MARKER_CACHE_KEY.formatted(geohash);
 		cacheManager.cache(key, writeValueAsString(markers), RedisTTLPolicy.MARKER_TTL);
 	}

--- a/src/main/java/com/example/log4u/domain/map/cache/manager/MarkersLocalCacheManager.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/manager/MarkersLocalCacheManager.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.example.log4u.domain.diary.entity.Diary;
 import com.example.log4u.domain.map.dto.response.GetDiaryMarkerResponse;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -17,18 +18,18 @@ public class MarkersLocalCacheManager {
 
 	private static final String MARKERS_CACHE_KEY = "marker:geohash:%s";
 
-	private final Cache<String, List<GetDiaryMarkerResponse>> markersLocalCache = Caffeine
+	private final Cache<String, List<Diary>> markersLocalCache = Caffeine
 		.newBuilder()
 		.recordStats()
 		.expireAfterWrite(Duration.ofMinutes(10))
 		.maximumSize(1)
 		.build();
 
-	public void cache(String geohash, List<GetDiaryMarkerResponse> markers) {
+	public void cache(String geohash, List<Diary> markers) {
 		markersLocalCache.put(MARKERS_CACHE_KEY.formatted(geohash), markers);
 	}
 
-	public List<GetDiaryMarkerResponse> load(String geohash) {
+	public List<Diary> load(String geohash) {
 		return markersLocalCache.getIfPresent(MARKERS_CACHE_KEY.formatted(geohash));
 	}
 

--- a/src/main/java/com/example/log4u/domain/map/controller/MapController.java
+++ b/src/main/java/com/example/log4u/domain/map/controller/MapController.java
@@ -79,17 +79,17 @@ public class MapController {
 
 	@Operation(summary = "다이어리 마커 조회 (Redis Cache)")
 	@GetMapping("/diaries/marker-redis")
-	public ResponseEntity<GetDiaryMarkersResponse> getMarkersByRedis(
+	public ResponseEntity<GetDiaryMarkersResponse> getTopLikedMarkersByRedisCache(
 		@Parameter(description = "조회 기준 geohash (예: 'wydm6')") @RequestParam String geohash) {
-		GetDiaryMarkersResponse response = mapService.getMarkersByRedisCache(geohash);
+		GetDiaryMarkersResponse response = mapService.getTopLikedMarkersByRedisCache(geohash);
 		return ResponseEntity.ok(response);
 	}
 
 	@Operation(summary = "다이어리 마커 조회 (Local Cache)")
 	@GetMapping("/diaries/marker-local-cache")
-	public ResponseEntity<GetDiaryMarkersResponse> getMarkersByLocalCache(
+	public ResponseEntity<GetDiaryMarkersResponse> getTopLikedMarkersByLocalCache(
 		@Parameter(description = "조회 기준 geohash (예: 'wydm6')") @RequestParam String geohash) {
-		GetDiaryMarkersResponse response = mapService.getMarkersByLocalCache(geohash);
+		GetDiaryMarkersResponse response = mapService.getTopLikedMarkersByLocalCache(geohash);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/example/log4u/domain/map/dto/response/GetDiaryMarkersResponse.java
+++ b/src/main/java/com/example/log4u/domain/map/dto/response/GetDiaryMarkersResponse.java
@@ -12,7 +12,7 @@ public record GetDiaryMarkersResponse(
 	List<GetDiaryMarkerResponse> markers
 ) {
 
-	public static GetDiaryMarkersResponse ofDiaries(List<Diary> diaries) {
+	public static GetDiaryMarkersResponse of(List<Diary> diaries) {
 		return new GetDiaryMarkersResponse(
 			diaries.stream()
 				.map(GetDiaryMarkerResponse::of)

--- a/src/main/java/com/example/log4u/domain/map/service/MapService.java
+++ b/src/main/java/com/example/log4u/domain/map/service/MapService.java
@@ -15,7 +15,6 @@ import com.example.log4u.domain.map.cache.MarkersCacheService;
 import com.example.log4u.domain.map.cache.MarkersLocalCacheService;
 import com.example.log4u.domain.map.dto.response.GetDiaryClusterResponse;
 import com.example.log4u.domain.map.dto.response.GetDiaryClustersResponse;
-import com.example.log4u.domain.map.dto.response.GetDiaryMarkerResponse;
 import com.example.log4u.domain.map.dto.response.GetDiaryMarkersResponse;
 import com.example.log4u.domain.map.entity.SidoAreas;
 import com.example.log4u.domain.map.entity.SiggAreas;
@@ -100,17 +99,17 @@ public class MapService {
 	}
 
 	@Transactional(readOnly = true)
-	public GetDiaryMarkersResponse getMarkersByRedisCache(String geohash) {
+	public GetDiaryMarkersResponse getTopLikedMarkersByRedisCache(String geohash) {
 		validateGeohashLength(geohash, 5);
-		List<GetDiaryMarkerResponse> diaryMarkers = markersCacheService.getMarkers(geohash);
-		return GetDiaryMarkersResponse.ofMarkers(diaryMarkers);
+		List<Diary> diaryMarkers = markersCacheService.getTopLikedMarkers(geohash);
+		return GetDiaryMarkersResponse.of(diaryMarkers);
 	}
 
 	@Transactional(readOnly = true)
-	public GetDiaryMarkersResponse getMarkersByLocalCache(String geohash) {
+	public GetDiaryMarkersResponse getTopLikedMarkersByLocalCache(String geohash) {
 		validateGeohashLength(geohash, 5);
-		List<GetDiaryMarkerResponse> markers = markersLocalCacheService.getMarkers(geohash);
-		return GetDiaryMarkersResponse.ofMarkers(markers);
+		List<Diary> markers = markersLocalCacheService.getTopLikedMarkers(geohash);
+		return GetDiaryMarkersResponse.of(markers);
 	}
 
 	public void increaseRegionDiaryCount(double lat, double lon) {

--- a/src/main/java/com/example/log4u/domain/map/service/MapService.java
+++ b/src/main/java/com/example/log4u/domain/map/service/MapService.java
@@ -89,14 +89,14 @@ public class MapService {
 	public GetDiaryMarkersResponse getMarkers(String geohash) {
 		validateGeohashLength(geohash, 5);
 		List<Diary> diaryMarkers = diaryService.getDiariesByGeohash(geohash);
-		return GetDiaryMarkersResponse.ofDiaries(diaryMarkers);
+		return GetDiaryMarkersResponse.of(diaryMarkers);
 	}
 
 	@Transactional(readOnly = true)
 	public GetDiaryMarkersResponse getMarkersByIndexScan(String geohash) {
 		validateGeohashLength(geohash, 5);
 		List<Diary> diaryMarkers = diaryService.getDiariesByGeohashByIndexScan(geohash);
-		return GetDiaryMarkersResponse.ofDiaries(diaryMarkers);
+		return GetDiaryMarkersResponse.of(diaryMarkers);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/test/java/com/example/log4u/domain/Map/service/MapCacheServiceTest.java
+++ b/src/test/java/com/example/log4u/domain/Map/service/MapCacheServiceTest.java
@@ -319,21 +319,20 @@ public class MapCacheServiceTest extends ServiceTest {
 		diaryRepository.save(diary);
 		diaryGeoHashRepository.save(diaryGeoHash);
 
+		// when
 		markersCacheService.refresh(geohash);
 
-		// when
-		List<GetDiaryMarkerResponse> markers = markersCacheService.getMarkers(geohash);
-
 		// then
+		List<Diary> markers = markersCacheService.getMarkers(geohash);
 		assertThat(markers).isNotNull();
 		assertThat(markers)
 			.extracting(
-				GetDiaryMarkerResponse::diaryId,
-				GetDiaryMarkerResponse::title,
-				GetDiaryMarkerResponse::thumbnailUrl,
-				GetDiaryMarkerResponse::lat,
-				GetDiaryMarkerResponse::lon,
-				GetDiaryMarkerResponse::likeCount)
+				Diary::getDiaryId,
+				Diary::getTitle,
+				Diary::getThumbnailUrl,
+				d -> d.getLocation().getLatitude(),
+				d -> d.getLocation().getLongitude(),
+				Diary::getLikeCount)
 			.containsExactly(
 				tuple(
 					diary.getDiaryId(),
@@ -412,18 +411,18 @@ public class MapCacheServiceTest extends ServiceTest {
 		markersCacheService.refresh(geohash);
 
 		// when
-		List<GetDiaryMarkerResponse> markers = markersCacheService.getMarkers(geohash);
+		List<Diary> markers = markersCacheService.getMarkers(geohash);
 
 		// then
 		assertThat(markers).isNotNull();
 		assertThat(markers)
 			.extracting(
-				GetDiaryMarkerResponse::diaryId,
-				GetDiaryMarkerResponse::title,
-				GetDiaryMarkerResponse::thumbnailUrl,
-				GetDiaryMarkerResponse::lat,
-				GetDiaryMarkerResponse::lon,
-				GetDiaryMarkerResponse::likeCount)
+				Diary::getDiaryId,
+				Diary::getTitle,
+				Diary::getThumbnailUrl,
+				d -> d.getLocation().getLatitude(),
+				d -> d.getLocation().getLongitude(),
+				Diary::getLikeCount)
 			.containsExactlyInAnyOrder(
 				tuple(
 					diary1.getDiaryId(),
@@ -440,4 +439,78 @@ public class MapCacheServiceTest extends ServiceTest {
 					diary2.getLocation().getLongitude(),
 					diary2.getLikeCount()));
 	}
+
+	@DisplayName("캐싱된 마커 목록을 조회하여 좋아요 순으로 정렬된 300개 미만의 마커 목록을 반환한다 ")
+	@Test
+	void getTopLikedMarkers() {
+		// given
+		String geohash = "wydm5";
+
+		Location location = Location.builder()
+			.latitude(37.5665)
+			.longitude(126.9780)
+			.sido("서울")
+			.sigungu("중구")
+			.eupmyeondong("명동")
+			.build();
+
+		Diary d1 = Diary.builder()
+			.userId(1L).diaryId(1L)
+			.title("다이어리1")
+			.thumbnailUrl("http://localhost:8080/thumb1")
+			.content("내용1")
+			.diaryDate(LocalDate.of(2026, 1, 1))
+			.location(location)
+			.weatherInfo(WeatherInfo.SUNNY)
+			.visibility(VisibilityType.PUBLIC)
+			.likeCount(3L)
+			.build();
+
+		Diary d2 = Diary.builder()
+			.userId(2L).diaryId(2L)
+			.title("다이어리2")
+			.thumbnailUrl("http://localhost:8080/thumb2")
+			.content("내용2")
+			.diaryDate(LocalDate.of(2026, 1, 2))
+			.location(location)
+			.weatherInfo(WeatherInfo.CLOUDY)
+			.visibility(VisibilityType.PUBLIC)
+			.likeCount(10L)
+			.build();
+
+		Diary d3 = Diary.builder()
+			.userId(3L).diaryId(3L)
+			.title("다이어리3")
+			.thumbnailUrl("http://localhost:8080/thumb3")
+			.content("내용3")
+			.diaryDate(LocalDate.of(2026, 1, 3))
+			.location(location)
+			.weatherInfo(WeatherInfo.RAINY)
+			.visibility(VisibilityType.PUBLIC)
+			.likeCount(7L)
+			.build();
+
+		diaryRepository.saveAll(List.of(d1, d2, d3));
+		diaryGeoHashRepository.saveAll(List.of(
+			DiaryGeoHash.builder().id(1L).diaryId(1L).geohash(geohash).build(),
+			DiaryGeoHash.builder().id(2L).diaryId(2L).geohash(geohash).build(),
+			DiaryGeoHash.builder().id(3L).diaryId(3L).geohash(geohash).build()
+		));
+
+		markersCacheService.refresh(geohash);
+
+		// when
+		List<Diary> result = markersCacheService.getTopLikedMarkers(geohash);
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result)
+			.extracting(Diary::getDiaryId, Diary::getLikeCount)
+			.containsExactly(
+				tuple(2L, 10L),
+				tuple(3L, 7L),
+				tuple(1L, 3L)
+			);
+	}
+
 }

--- a/src/test/java/com/example/log4u/domain/Map/service/MapLocalCacheServiceTest.java
+++ b/src/test/java/com/example/log4u/domain/Map/service/MapLocalCacheServiceTest.java
@@ -188,13 +188,13 @@ public class MapLocalCacheServiceTest extends ServiceTest {
 					siggAreasDiaryCount2.getDiaryCount()));
 	}
 
-	@DisplayName("로컬 캐싱된 마커 목록을 조회한다.")
+	@DisplayName("로컬 캐싱된 마커 목록을 조회하여 좋아요 순으로 정렬된 300개 미만의 마커 목록을 반환한다 ")
 	@Test
-	void getMarkers() {
+	void getTopLikedMarkers() {
 		// given
 		String geohash = "wydm5";
 
-		Location location1 = Location.builder()
+		Location location = Location.builder()
 			.latitude(37.5665)
 			.longitude(126.9780)
 			.sido("서울")
@@ -202,84 +202,63 @@ public class MapLocalCacheServiceTest extends ServiceTest {
 			.eupmyeondong("명동")
 			.build();
 
-		Location location2 = Location.builder()
-			.latitude(37.5650)
-			.longitude(126.9760)
-			.sido("서울")
-			.sigungu("중구")
-			.eupmyeondong("을지로")
-			.build();
-
-		Diary diary1 = Diary.builder()
-			.userId(1L)
-			.diaryId(1L)
+		Diary d1 = Diary.builder()
+			.userId(1L).diaryId(1L)
 			.title("다이어리1")
 			.thumbnailUrl("http://localhost:8080/thumb1")
 			.content("내용1")
 			.diaryDate(LocalDate.of(2026, 1, 1))
-			.location(location1)
+			.location(location)
 			.weatherInfo(WeatherInfo.SUNNY)
 			.visibility(VisibilityType.PUBLIC)
 			.likeCount(3L)
 			.build();
 
-		Diary diary2 = Diary.builder()
-			.userId(2L)
-			.diaryId(2L)
+		Diary d2 = Diary.builder()
+			.userId(2L).diaryId(2L)
 			.title("다이어리2")
 			.thumbnailUrl("http://localhost:8080/thumb2")
 			.content("내용2")
 			.diaryDate(LocalDate.of(2026, 1, 2))
-			.location(location2)
+			.location(location)
 			.weatherInfo(WeatherInfo.CLOUDY)
 			.visibility(VisibilityType.PUBLIC)
 			.likeCount(10L)
 			.build();
 
-		DiaryGeoHash diaryGeoHash1 = DiaryGeoHash.builder()
-			.id(1L)
-			.diaryId(diary1.getDiaryId())
-			.geohash("wydm5")
+		Diary d3 = Diary.builder()
+			.userId(3L).diaryId(3L)
+			.title("다이어리3")
+			.thumbnailUrl("http://localhost:8080/thumb3")
+			.content("내용3")
+			.diaryDate(LocalDate.of(2026, 1, 3))
+			.location(location)
+			.weatherInfo(WeatherInfo.RAINY)
+			.visibility(VisibilityType.PUBLIC)
+			.likeCount(7L)
 			.build();
 
-		DiaryGeoHash diaryGeoHash2 = DiaryGeoHash.builder()
-			.id(2L)
-			.diaryId(diary2.getDiaryId())
-			.geohash("wydm5")
-			.build();
+		diaryRepository.saveAll(List.of(d1, d2, d3));
+		diaryGeoHashRepository.saveAll(List.of(
+			DiaryGeoHash.builder().id(1L).diaryId(1L).geohash(geohash).build(),
+			DiaryGeoHash.builder().id(2L).diaryId(2L).geohash(geohash).build(),
+			DiaryGeoHash.builder().id(3L).diaryId(3L).geohash(geohash).build()
+		));
 
-		diaryRepository.save(diary1);
-		diaryRepository.save(diary2);
-		diaryGeoHashRepository.save(diaryGeoHash1);
-		diaryGeoHashRepository.save(diaryGeoHash2);
+		markersLocalCacheService.refresh(geohash);
 
 		// when
-		List<GetDiaryMarkerResponse> markers = markersLocalCacheService.getMarkers(geohash);
+		List<Diary> result = markersLocalCacheService.getTopLikedMarkers(geohash);
 
 		// then
-		assertThat(markers).isNotNull();
-		assertThat(markers)
-			.extracting(
-				GetDiaryMarkerResponse::diaryId,
-				GetDiaryMarkerResponse::title,
-				GetDiaryMarkerResponse::thumbnailUrl,
-				GetDiaryMarkerResponse::lat,
-				GetDiaryMarkerResponse::lon,
-				GetDiaryMarkerResponse::likeCount)
-			.containsExactlyInAnyOrder(
-				tuple(
-					diary1.getDiaryId(),
-					diary1.getTitle(),
-					diary1.getThumbnailUrl(),
-					diary1.getLocation().getLatitude(),
-					diary1.getLocation().getLongitude(),
-					diary1.getLikeCount()),
-				tuple(
-					diary2.getDiaryId(),
-					diary2.getTitle(),
-					diary2.getThumbnailUrl(),
-					diary2.getLocation().getLatitude(),
-					diary2.getLocation().getLongitude(),
-					diary2.getLikeCount()));
+		assertThat(result).hasSize(3);
+		assertThat(result)
+			.extracting(Diary::getDiaryId, Diary::getLikeCount)
+			.containsExactly(
+				tuple(2L, 10L),
+				tuple(3L, 7L),
+				tuple(1L, 3L)
+			);
 	}
+
 }

--- a/src/test/java/com/example/log4u/domain/Map/service/MapServiceTest.java
+++ b/src/test/java/com/example/log4u/domain/Map/service/MapServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.example.log4u.common.ServiceTest;
@@ -37,7 +36,7 @@ class MapServiceTest extends ServiceTest {
 		String geohash = "wydm6ef2";
 
 		// when, then
-		assertThatThrownBy(() -> mapService.getMarkersByRedisCache(geohash))
+		assertThatThrownBy(() -> mapService.getTopLikedMarkersByRedisCache(geohash))
 			.isInstanceOf(InvalidGeohashException.class)
 			.hasMessage(INVALID_GEOHASH.getErrorMessage());
 	}


### PR DESCRIPTION


## ✨ 변경 사항
<!-- 이번 PR에서 변경된 내용을 요약하여 설명 -->
- 마커 목록 캐싱 대상을 DTO에서 Entity(Diary)로 변경
- 캐싱된 마커 조회 시 좋아요 상위 300개만 반환하도록 제한

## 🔍 변경 이유
<!-- 이번 PR이 필요한 이유 또는 해결하는 문제 -->
- 특정 핫한 구역에 대한 마커 캐싱 API 부하 테스트 결과, 캐시된 마커 데이터의 크기가 커 네트워크 전송 과정에서 병목이 발생하며 TPS가 저하되는 문제를 확인함. 
- 이에 따라 마커 캐시 데이터를 Entity 기반으로 변경하여 조회 정책(정렬/필터링)을 유연하게 적용하고, 좋아요 기준 상위 300개만 반환하도록 제한하여 응답 크기 및 전송 비용을 감소시킴

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항 -->
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 관련 테스트 코드 작성 및 통과 여부 확인
- [x] 문서화(README 등) 필요 여부 확인 및 반영
- [x] 리뷰어가 알아야 할 사항 추가 설명

## 📸 스크린샷 (선택)
<!-- UI 변경이 포함된 경우 관련 스크린샷 첨부 -->

## 📌 참고 사항
<!-- 기타 리뷰어가 참고해야 할 사항 -->
