### PR TITLE
Redis Pub/Sub 기반 지도 클러스터/마커 로컬 캐시 무효화 적용

### DIFF
--- a/src/main/java/com/example/log4u/common/config/redis/RedisConfig.java
+++ b/src/main/java/com/example/log4u/common/config/redis/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -35,5 +36,12 @@ public class RedisConfig {
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.registerModule(new JavaTimeModule());
 		return objectMapper;
+	}
+
+	@Bean
+	public RedisMessageListenerContainer redisMessageListenerContainer() {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(redisConnectionFactory);
+		return container;
 	}
 }

--- a/src/main/java/com/example/log4u/common/infra/local_cache/LocalCacheManager.java
+++ b/src/main/java/com/example/log4u/common/infra/local_cache/LocalCacheManager.java
@@ -1,0 +1,64 @@
+package com.example.log4u.common.infra.local_cache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.example.log4u.common.infra.local_cache.message_publisher.MessagePublisher;
+import com.example.log4u.common.infra.local_cache.message_subscriber.MessageSubscriber;
+import com.github.benmanes.caffeine.cache.Cache;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LocalCacheManager {
+
+    private static final String INVALIDATE_CACHE_CHANNEL = "invalidate-cache";
+
+    private final MessagePublisher messagePublisher;
+    private final MessageSubscriber messageSubscriber;
+
+    private final Map<String, Object> localCaches = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        setMessageListenerOfSubscriber();
+    }
+
+    public void addLocalCache(String localCacheName, Object localCache) {
+        localCaches.put(localCacheName, localCache);
+    }
+
+    public void publishInvalidateCacheMessage(String localCacheName, String key) {
+        String message = localCacheName + ":" + key;
+        messagePublisher.publish(INVALIDATE_CACHE_CHANNEL, message);
+    }
+
+    private void setMessageListenerOfSubscriber() {
+        messageSubscriber.addMessageListener(
+            INVALIDATE_CACHE_CHANNEL,
+            (message, pattern) -> invalidateCache(message.getBody())
+        );
+    }
+
+    private void invalidateCache(byte[] message) {
+        String payload = messageSubscriber.parseMessage(message);
+        String[] parts = payload.split(":", 2);
+
+        String cacheName = parts[0];
+        String key       = parts[1];
+        if (!localCaches.containsKey(cacheName)) {
+            throw new IllegalArgumentException("Invalid local cache name: " + cacheName);
+        }
+
+        Cache<String, Object> localCache = (Cache<String, Object>) localCaches.get(cacheName);
+        localCache.invalidate(key);
+    }
+
+}
+

--- a/src/main/java/com/example/log4u/common/infra/local_cache/message_publisher/MessagePublisher.java
+++ b/src/main/java/com/example/log4u/common/infra/local_cache/message_publisher/MessagePublisher.java
@@ -1,0 +1,6 @@
+package com.example.log4u.common.infra.local_cache.message_publisher;
+
+public interface MessagePublisher {
+
+    void publish(String channel, String message);
+}

--- a/src/main/java/com/example/log4u/common/infra/local_cache/message_publisher/RedisMessagePublisherImpl.java
+++ b/src/main/java/com/example/log4u/common/infra/local_cache/message_publisher/RedisMessagePublisherImpl.java
@@ -1,0 +1,17 @@
+package com.example.log4u.common.infra.local_cache.message_publisher;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisMessagePublisherImpl implements MessagePublisher {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void publish(String channel, String message) {
+        redisTemplate.convertAndSend(channel, message);
+    }
+}

--- a/src/main/java/com/example/log4u/common/infra/local_cache/message_subscriber/MessageSubscriber.java
+++ b/src/main/java/com/example/log4u/common/infra/local_cache/message_subscriber/MessageSubscriber.java
@@ -1,0 +1,10 @@
+package com.example.log4u.common.infra.local_cache.message_subscriber;
+
+import org.springframework.data.redis.connection.MessageListener;
+
+public interface MessageSubscriber {
+
+    void addMessageListener(String channel, MessageListener listener);
+
+    String parseMessage(byte[] message);
+}

--- a/src/main/java/com/example/log4u/common/infra/local_cache/message_subscriber/RedisMessageSubscriberImpl.java
+++ b/src/main/java/com/example/log4u/common/infra/local_cache/message_subscriber/RedisMessageSubscriberImpl.java
@@ -1,0 +1,29 @@
+package com.example.log4u.common.infra.local_cache.message_subscriber;
+
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisMessageSubscriberImpl implements MessageSubscriber {
+
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void addMessageListener(String channel, MessageListener messageListener) {
+        redisMessageListenerContainer.addMessageListener(
+                messageListener,
+                new ChannelTopic(channel));
+    }
+
+    @Override
+    public String parseMessage(byte[] message) {
+        return (String) redisTemplate.getValueSerializer().deserialize(message);
+    }
+}

--- a/src/main/java/com/example/log4u/domain/map/cache/ClustersLocalCacheService.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/ClustersLocalCacheService.java
@@ -2,6 +2,7 @@ package com.example.log4u.domain.map.cache;
 
 import java.util.List;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.example.log4u.common.executor.RetryExecutor;
@@ -19,6 +20,11 @@ public class ClustersLocalCacheService {
 	private final ClustersLocalCacheManager clustersLocalCacheManager;
 
 	private final RetryExecutor retryExecutor;
+
+	@Scheduled(cron = "0 0/10 * * * ?")
+	public void refreshOnSchedule() {
+		clustersLocalCacheManager.evictAll();
+	}
 
 	public void refresh(String geohash, int level) {
 		clustersCacheManager.refresh(geohash, level);

--- a/src/main/java/com/example/log4u/domain/map/cache/MarkersCacheService.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/MarkersCacheService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.example.log4u.common.executor.RetryExecutor;
 import com.example.log4u.domain.diary.entity.Diary;
 import com.example.log4u.domain.map.cache.manager.MarkersCacheManager;
+import com.example.log4u.domain.map.cache.support.DiaryUtils;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/example/log4u/domain/map/cache/MarkersLocalCacheService.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/MarkersLocalCacheService.java
@@ -1,13 +1,16 @@
 package com.example.log4u.domain.map.cache;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.example.log4u.common.executor.RetryExecutor;
 import com.example.log4u.domain.diary.entity.Diary;
 import com.example.log4u.domain.map.cache.manager.MarkersCacheManager;
 import com.example.log4u.domain.map.cache.manager.MarkersLocalCacheManager;
+import com.example.log4u.domain.map.cache.support.DiaryUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +22,11 @@ public class MarkersLocalCacheService {
 	private final MarkersLocalCacheManager markersLocalCacheManager;
 
 	private final RetryExecutor retryExecutor;
+
+	@Scheduled(cron = "0 0/10 * * * ?")
+	public void refreshOnSchedule() {
+		markersLocalCacheManager.evictAll();
+	}
 
 	public void refresh(String geohash) {
 		markersCacheManager.refresh(geohash);

--- a/src/main/java/com/example/log4u/domain/map/cache/manager/ClustersCacheManager.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/manager/ClustersCacheManager.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.example.log4u.common.executor.DistributedLockExecutor;
 import com.example.log4u.common.infra.cache.CacheManager;
-import com.example.log4u.domain.map.cache.RedisTTLPolicy;
+import com.example.log4u.domain.map.cache.support.RedisTTLPolicy;
 import com.example.log4u.domain.map.dto.response.GetDiaryClusterResponse;
 import com.example.log4u.domain.map.exception.InvalidMapLevelException;
 import com.example.log4u.domain.map.repository.sido.SidoAreasRepository;

--- a/src/main/java/com/example/log4u/domain/map/cache/manager/ClustersLocalCacheManager.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/manager/ClustersLocalCacheManager.java
@@ -5,10 +5,12 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.example.log4u.common.infra.local_cache.LocalCacheManager;
 import com.example.log4u.domain.map.dto.response.GetDiaryClusterResponse;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,14 +19,27 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ClustersLocalCacheManager {
 
+	private static final String CLUSTERS_CACHE_NAME = "clusters";
 	private static final String CLUSTERS_CACHE_KEY = "cluster:geohash:%s:level:%d";
+
+	private final LocalCacheManager localCacheManager;
 
 	private final Cache<String, List<GetDiaryClusterResponse>> clustersLocalCache = Caffeine
 		.newBuilder()
 		.recordStats()
 		.expireAfterWrite(Duration.ofMinutes(10))
-		.maximumSize(1)
+		.maximumSize(5)
 		.build();
+
+	@PostConstruct
+	public void registerCache() {
+		localCacheManager.addLocalCache(CLUSTERS_CACHE_NAME, clustersLocalCache);
+	}
+
+	public void evict(String geohash, int level) {
+		String key = CLUSTERS_CACHE_KEY.formatted(geohash, level);
+		localCacheManager.publishInvalidateCacheMessage(CLUSTERS_CACHE_NAME, key);
+	}
 
 	public void cache(String geohash, int level, List<GetDiaryClusterResponse> clusters) {
 		String key = CLUSTERS_CACHE_KEY.formatted(geohash, level);
@@ -36,8 +51,7 @@ public class ClustersLocalCacheManager {
 		return clustersLocalCache.getIfPresent(key);
 	}
 
-	public void evict(String geohash, int level) {
-		String key = CLUSTERS_CACHE_KEY.formatted(geohash, level);
-		clustersLocalCache.invalidate(key);
+	public void evictAll() {
+		clustersLocalCache.invalidateAll();
 	}
 }

--- a/src/main/java/com/example/log4u/domain/map/cache/manager/MarkersCacheManager.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/manager/MarkersCacheManager.java
@@ -10,8 +10,7 @@ import com.example.log4u.common.executor.DistributedLockExecutor;
 import com.example.log4u.common.infra.cache.CacheManager;
 import com.example.log4u.domain.diary.entity.Diary;
 import com.example.log4u.domain.diary.repository.DiaryRepository;
-import com.example.log4u.domain.map.cache.RedisTTLPolicy;
-import com.example.log4u.domain.map.dto.response.GetDiaryMarkerResponse;
+import com.example.log4u.domain.map.cache.support.RedisTTLPolicy;
 import com.fasterxml.jackson.core.type.TypeReference;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/log4u/domain/map/cache/manager/MarkersLocalCacheManager.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/manager/MarkersLocalCacheManager.java
@@ -6,34 +6,52 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.example.log4u.domain.diary.entity.Diary;
-import com.example.log4u.domain.map.dto.response.GetDiaryMarkerResponse;
+import com.example.log4u.common.infra.local_cache.LocalCacheManager;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MarkersLocalCacheManager {
 
+	private static final String MARKERS_CACHE_NAME = "markers";
 	private static final String MARKERS_CACHE_KEY = "marker:geohash:%s";
+
+	private final LocalCacheManager localCacheManager;
 
 	private final Cache<String, List<Diary>> markersLocalCache = Caffeine
 		.newBuilder()
 		.recordStats()
 		.expireAfterWrite(Duration.ofMinutes(10))
-		.maximumSize(1)
+		.maximumSize(5)
 		.build();
 
-	public void cache(String geohash, List<Diary> markers) {
-		markersLocalCache.put(MARKERS_CACHE_KEY.formatted(geohash), markers);
-	}
-
-	public List<Diary> load(String geohash) {
-		return markersLocalCache.getIfPresent(MARKERS_CACHE_KEY.formatted(geohash));
+	@PostConstruct
+	public void registerCache() {
+		localCacheManager.addLocalCache(MARKERS_CACHE_NAME, markersLocalCache);
 	}
 
 	public void evict(String geohash) {
-		markersLocalCache.invalidate(MARKERS_CACHE_KEY.formatted(geohash));
+		String key = MARKERS_CACHE_KEY.formatted(geohash);
+		localCacheManager.publishInvalidateCacheMessage(MARKERS_CACHE_NAME, key);
+	}
+
+	public void cache(String geohash, List<Diary> markers) {
+		String key = MARKERS_CACHE_KEY.formatted(geohash);
+		markersLocalCache.put(key, markers);
+	}
+
+	public List<Diary> load(String geohash) {
+		String key = MARKERS_CACHE_KEY.formatted(geohash);
+		return markersLocalCache.getIfPresent(key);
+	}
+
+	public void evictAll() {
+		markersLocalCache.invalidateAll();
 	}
 }

--- a/src/main/java/com/example/log4u/domain/map/cache/support/DiaryUtils.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/support/DiaryUtils.java
@@ -1,4 +1,4 @@
-package com.example.log4u.domain.map.cache;
+package com.example.log4u.domain.map.cache.support;
 
 import java.util.List;
 

--- a/src/main/java/com/example/log4u/domain/map/cache/support/RedisTTLPolicy.java
+++ b/src/main/java/com/example/log4u/domain/map/cache/support/RedisTTLPolicy.java
@@ -1,4 +1,4 @@
-package com.example.log4u.domain.map.cache;
+package com.example.log4u.domain.map.cache.support;
 
 import java.time.Duration;
 


### PR DESCRIPTION


## ✨ 변경 사항
<!-- 이번 PR에서 변경된 내용을 요약하여 설명 -->
- 지도 클러스터/마커 조회에 Redis Pub/Sub 기반 로컬 캐시 무효화 구조 도입
- 서버 간 로컬 캐시 불일치 문제를 해결하기 위해 invalidate 메시지 브로드캐스트 처리
- Local cache(Caffeine) / Global cache(Redis) 역할을 분리하고, 이벤트 기반 캐시 갱신 + TTL/스케줄러 적용

## 🔍 변경 이유
<!-- 이번 PR이 필요한 이유 또는 해결하는 문제 -->
- TPS 향상을 위해 Local Cache를 사용하는 경우, 서버 간 캐시 데이터가 갱신되었는지 여부를 각 서버가 인지할 수 없는 문제가 존재
- 캐시 갱신 이벤트를 Redis Pub/Sub으로 브로드캐스트하여 서버의 Local Cache를 무효화하고 다음 조회 시 최신 데이터로 재적재
- Pub/Sub 특성상 메시지 누락 가능성을 고려하여 Local Cache TTL 및 주기적 무효화 스케줄러 적용

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항 -->
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 관련 테스트 코드 작성 및 통과 여부 확인
- [x] 문서화(README 등) 필요 여부 확인 및 반영
- [x] 리뷰어가 알아야 할 사항 추가 설명

## 📸 스크린샷 (선택)
<!-- UI 변경이 포함된 경우 관련 스크린샷 첨부 -->

## 📌 참고 사항
<!-- 기타 리뷰어가 참고해야 할 사항 -->
